### PR TITLE
Fix unexpected token error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export function viteSingleFile(): Plugin {
 			enforce: "post",
 			transform(html: string, ctx?: IndexHtmlTransformContext): IndexHtmlTransformResult {
 				// Only use this plugin during build
-				if (!ctx?.bundle) return html
+				if (!ctx || !ctx.bundle) return html
 				// Get the bundle
 				let extraCode = ""
 				for (const [, value] of Object.entries(ctx.bundle)) {


### PR DESCRIPTION
When trying to use this plugin, I ran into the following error:

```
                if (!ctx?.bundle)
                         ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:931:16)
    at Module._compile (internal/modules/cjs/loader.js:979:27)
    at Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
```

This can be fixed by removing the `?` operator and replacing with a more explicit check