### PR TITLE
fix: don't add failed inline comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,27 @@
 {
 	"name": "vite-plugin-singlefile",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vite-plugin-singlefile",
-			"version": "0.6.2",
+			"version": "0.6.3",
 			"license": "MIT",
 			"dependencies": {
-				"@rollup/plugin-node-resolve": "^13.0.6",
-				"esbuild": "^0.14.3",
-				"rollup": "^2.42.1",
-				"rollup-plugin-esbuild": "^4.7.2"
+				"@rollup/plugin-node-resolve": "^13.1.2",
+				"chalk": "^4.1.2",
+				"esbuild": "^0.14.10",
+				"rollup": "^2.62.0",
+				"rollup-plugin-esbuild": "^4.8.2"
 			},
 			"devDependencies": {
 				"@types/ws": "^8.2.2",
 				"rimraf": "^3.0.2",
-				"typescript": "^4.2.3"
+				"typescript": "^4.5.4"
 			},
 			"peerDependencies": {
-				"vite": "^2.1.2"
+				"vite": "^2.7.10"
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
@@ -85,6 +86,20 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -111,6 +126,37 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -452,6 +498,14 @@
 				"node": ">= 0.4.0"
 			}
 		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -668,6 +722,17 @@
 			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/typescript": {
@@ -1028,6 +1093,14 @@
 				"@types/node": "*"
 			}
 		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1048,6 +1121,28 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
 			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
+		},
+		"chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1250,6 +1345,11 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1410,6 +1510,14 @@
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
 			"integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
 			"peer": true
+		},
+		"supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
 		},
 		"typescript": {
 			"version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -1,54 +1,55 @@
 {
-	"name": "vite-plugin-singlefile",
-	"version": "0.6.3",
-	"description": "Vite plugin for inlining JavaScript and CSS resources",
-	"main": "dist/index.js",
-	"typings": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"dev": "rimraf dist && tsc -w --p tsconfig.json",
-		"build": "rimraf dist && tsc -p tsconfig.json",
-		"prepublishOnly": "npm run build"
-	},
-	"keywords": [
-		"vite",
-		"inline",
-		"css",
-		"SFA",
-		"single-file"
-	],
-	"author": "richard@tallent.us",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/richardtallent/vite-plugin-singlefile"
-	},
-	"bugs": {
-		"url": "https://github.com/richardtallent/vite-plugin-singlefile/issues"
-	},
-	"homepage": "https://github.com/richardtallent/vite-plugin-singlefile/tree/main/#readme",
-	"dependencies": {
-		"@rollup/plugin-node-resolve": "^13.1.2",
-		"esbuild": "^0.14.10",
-		"rollup": "^2.62.0",
-		"rollup-plugin-esbuild": "^4.8.2"
-	},
-	"peerDependencies": {
-		"vite": "^2.7.10"
-	},
-	"devDependencies": {
-		"@types/ws": "^8.2.2",
-		"rimraf": "^3.0.2",
-		"typescript": "^4.5.4"
-	},
-	"prettier": {
-		"useTabs": true,
-		"semi": false,
-		"singleQuote": false,
-		"bracketSpacing": true,
-		"trailingComma": "es5",
-		"printWidth": 180
-	}
+  "name": "vite-plugin-singlefile",
+  "version": "0.6.3",
+  "description": "Vite plugin for inlining JavaScript and CSS resources",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "rimraf dist && tsc -w --p tsconfig.json",
+    "build": "rimraf dist && tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "vite",
+    "inline",
+    "css",
+    "SFA",
+    "single-file"
+  ],
+  "author": "richard@tallent.us",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/richardtallent/vite-plugin-singlefile"
+  },
+  "bugs": {
+    "url": "https://github.com/richardtallent/vite-plugin-singlefile/issues"
+  },
+  "homepage": "https://github.com/richardtallent/vite-plugin-singlefile/tree/main/#readme",
+  "dependencies": {
+    "@rollup/plugin-node-resolve": "^13.1.2",
+    "chalk": "^4.1.2",
+    "esbuild": "^0.14.10",
+    "rollup": "^2.62.0",
+    "rollup-plugin-esbuild": "^4.8.2"
+  },
+  "peerDependencies": {
+    "vite": "^2.7.10"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.2.2",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.5.4"
+  },
+  "prettier": {
+    "useTabs": true,
+    "semi": false,
+    "singleQuote": false,
+    "bracketSpacing": true,
+    "trailingComma": "es5",
+    "printWidth": 180
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,35 @@
 import { IndexHtmlTransformResult, IndexHtmlTransformContext } from "vite"
 import { Plugin } from "vite"
 import { OutputChunk, OutputAsset } from "rollup"
+import chalk from "chalk"
 
 export function viteSingleFile(): Plugin {
-	return {
-		name: "vite:singlefile",
-		transformIndexHtml: {
-			enforce: "post",
-			transform(html: string, ctx?: IndexHtmlTransformContext): IndexHtmlTransformResult {
-				// Only use this plugin during build
-				if (!ctx || !ctx.bundle) return html
-				// Get the bundle
-				let extraCode = ""
-				for (const [, value] of Object.entries(ctx.bundle)) {
-					const o = value as OutputChunk
-					const a = value as OutputAsset
-					if (o.code) {
-						const reScript = new RegExp(`<script type="module"[^>]*?src="[\./]*${value.fileName}"[^>]*?></script>`)
-						const code = `<script type="module">\n//${o.fileName}\n${o.code}\n</script>`
-						html = html.replace(reScript, (_) => code)
-					} else if (value.fileName.endsWith(".css")) {
-						const reCSS = new RegExp(`<link rel="stylesheet"[^>]*?href="[\./]*${value.fileName}"[^>]*?>`)
-						const code = `<!-- ${a.fileName} --><style type="text/css">\n${a.source}\n</style>`
-						html = html.replace(reCSS, (_) => code)
-					} else {
-						extraCode += "\n<!-- ASSET NOT INLINED: " + a.fileName + " -->\n"
-					}
-				}
-				return html.replace(/<\/body>/, extraCode + "</body>")
-			},
-		},
-	}
+  return {
+    name: "vite:singlefile",
+    transformIndexHtml: {
+      enforce: "post",
+      transform(html: string, ctx?: IndexHtmlTransformContext): IndexHtmlTransformResult {
+        // Only use this plugin during build
+        if (!ctx || !ctx.bundle) return html
+        // Get the bundle
+        let extraCode = ""
+        for (const [, value] of Object.entries(ctx.bundle)) {
+          const o = value as OutputChunk
+          const a = value as OutputAsset
+          if (o.code) {
+            const reScript = new RegExp(`<script type="module"[^>]*?src="[\./]*${value.fileName}"[^>]*?></script>`)
+            const code = `<script type="module">\n//${o.fileName}\n${o.code}\n</script>`
+            html = html.replace(reScript, (_) => code)
+          } else if (value.fileName.endsWith(".css")) {
+            const reCSS = new RegExp(`<link rel="stylesheet"[^>]*?href="[\./]*${value.fileName}"[^>]*?>`)
+            const code = `<!-- ${a.fileName} --><style type="text/css">\n${a.source}\n</style>`
+            html = html.replace(reCSS, (_) => code)
+          } else {
+            console.warn(`${chalk.yellow('WARN')} asset not inlined: ${chalk.green(a.fileName)}`)
+          }
+        }
+        return html.replace(/<\/body>/, extraCode + "</body>")
+      },
+    },
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,19 @@
 {
-	"compilerOptions": {
-		"target": "esnext",
-		"module": "commonjs",
-		"lib": ["esnext"],
-		"moduleResolution": "node",
-		"outDir": "dist",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"sourceMap": false,
-		"declaration": true,
-		"declarationDir": "dist",
-		"declarationMap": false
-	},
-	"include": ["./src"],
-	"exclude": ["node_modules"]
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": false,
+    "declaration": true,
+    "declarationDir": "dist",
+    "declarationMap": false
+  },
+  "include": ["./src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Adding the comments `<!-- ASSET NOT INLINED: ${a.fileName} -->` was making Chrome upset (the specific error was: `HTML comments are not allowed in modules`). I am not sure if this was specific to my set up. 

I don't think adding the comments is that helpful so I added a warning during build. Let me know if you want any changes or if this is unnecessary!