### PR TITLE
Remove inlined files from the bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ export default defineConfig({
 - `favicon` resources are not inlined by Vite, and this plugin doesn't do that either.
 - There may be other situations where referenced files aren't inlined by Vite and aren't caught by this plugin either. I've done little testing so far, I just wanted to get this out there first.
 - This is my first Vite and first Rollup plugin. I have no idea what I'm doing. PRs welcome.
-- This doesn't _remove_ the build artifacts from the `dist` folder, it just embeds them in the `index.html`. You can ignore the extra files. I'd be open to a PR to remove the recognized files so the `dist` folder is cleaner, especially if there's a way to just prevent them from being written in the first place (_i.e._, not having to delete the files).
 
 ### Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ export function viteSingleFile(): Plugin {
 				// Only use this plugin during build
 				if (!ctx || !ctx.bundle) return html
 				// Get the bundle
-				let extraCode = ""
 				for (const [, value] of Object.entries(ctx.bundle)) {
 					const o = value as OutputChunk
 					const a = value as OutputAsset
@@ -20,15 +19,17 @@ export function viteSingleFile(): Plugin {
 						const reScript = new RegExp(`<script type="module"[^>]*?src="[\./]*${o.fileName}"[^>]*?></script>`)
 						const code = `<script type="module">\n//${o.fileName}\n${o.code}\n</script>`
 						html = html.replace(reScript, (_) => code)
+						delete ctx.bundle[o.fileName]
 					} else if (a.fileName.endsWith(".css")) {
 						const reCSS = new RegExp(`<link rel="stylesheet"[^>]*?href="[\./]*${a.fileName}"[^>]*?>`)
 						const code = `<style type="text/css">\n${a.source}\n</style>`
 						html = html.replace(reCSS, (_) => code)
+						delete ctx.bundle[a.fileName]
 					} else {
 						console.warn(`${chalk.yellow("WARN")} asset not inlined: ${chalk.green(a.fileName)}`)
 					}
 				}
-				return html.replace(/<\/body>/, extraCode + "</body>")
+				return html
 			},
 		},
 	}


### PR DESCRIPTION
I changed it so that after a file is processed it'll delete the entry from the bundle. This prevents the file from being written into `dist`. I also removed the `extraCode` variable as it didn't look like it did anything, but it's possible that I overlooked something.