### PR TITLE
Add option to use recommended build config to simplify plugin usage. Also update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,36 +29,34 @@ import { viteSingleFile } from "vite-plugin-singlefile"
 
 export default defineConfig({
 	plugins: [vue(), viteSingleFile()],
-	build: {
-		target: "esnext",
-		assetsInlineLimit: 100000000,
-		chunkSizeWarningLimit: 100000000,
-		cssCodeSplit: false,
-		brotliSize: false,
-		rollupOptions: {
-			inlineDynamicImports: true,
-			output: {
-				manualChunks: () => "everything.js",
-			},
-		},
-	},
 })
 ```
 
-- The `assetsInlineLimit` ensures that even very large assets are inlined in your JavaScript.
-- The `chunkSizeWarningLimit` option just avoids the warnings about large chunks.
-- The `cssCodeSplit` option results in all CSS being emitted as a single file, which `vite-plugin-singlefile` can then inline.
-- The `brotliSize` option just avoids the extra step of testing Brotli compression, which isn't really pertinent to a file served locally.
-- The `inlineDynamicImports` also ensures that as many resources as possible are inlined.
-- The `manualChunks` option became necessary somewhere around Vite 2.0 release to prevent the creation of a separate `vendor.js` bundle. The filename you choose for `manualChunks` ultimately doesn't matter, it will get rolled into `index.html` by the plugin.`outputOptions` became just `output` some time after that. This is _apparently_ [not needed](https://github.com/vitejs/vite/discussions/2462#discussioncomment-2444172) as of Vite 2.9, but I'm leaving it here for now in case folks are still using older versions of Vite.
-
 ### Config
 
-You can optionally include a config to optimize your build:
+You can optionally include a config object to optimize your build:
+
+```ts
+viteSingleFile({ removeViteModuleLoader: true })
+```
+
+Here's a full reference of available options:
 
 ```ts
 viteSingleFile({
-	removeViteModuleLoader: true, // Remove the unused vite module loader. Safe to do since all JS is inlined by this plugin.
+	/**
+	 * Modifies the Vite build config to make this plugin work well.
+	 * See plugin implementation for more details on how this works.
+	 *
+	 * @default true
+	 */
+	useRecommendedBuildConfig: true,
+	/**
+	 * Remove the unused Vite module loader. Safe to do since all JS is inlined by this plugin.
+	 *
+	 * @default false
+	 */
+	removeViteModuleLoader: true,
 })
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,29 @@
-import { IndexHtmlTransformResult, IndexHtmlTransformContext } from "vite"
-import { Plugin } from "vite"
-import { OutputChunk, OutputAsset } from "rollup"
+import { IndexHtmlTransformResult, IndexHtmlTransformContext, UserConfig, Plugin } from "vite"
+import { OutputChunk, OutputAsset, OutputOptions } from "rollup"
 import chalk from "chalk"
 
-export type Config = { removeViteModuleLoader?: boolean }
+export type Config = {
+	/**
+	 * Modifies the Vite build config to make this plugin work well.
+	 * See plugin implementation for more details on how this works.
+	 *
+	 * @default true
+	 */
+	useRecommendedBuildConfig?: boolean
+	/**
+	 * Remove the unused Vite module loader. Safe to do since all JS is inlined by this plugin.
+	 *
+	 * @default false
+	 */
+	removeViteModuleLoader?: boolean
+}
 
-export function viteSingleFile({ removeViteModuleLoader = false }: Config = {}): Plugin {
+const defaultConfig = { useRecommendedBuildConfig: true, removeViteModuleLoader: false }
+
+export function viteSingleFile({ useRecommendedBuildConfig = true, removeViteModuleLoader = false }: Config = defaultConfig): Plugin {
 	return {
 		name: "vite:singlefile",
+		config: useRecommendedBuildConfig ? _useRecommendedBuildConfig : undefined,
 		transformIndexHtml: {
 			enforce: "post",
 			transform(html: string, ctx?: IndexHtmlTransformContext): IndexHtmlTransformResult {
@@ -44,4 +60,37 @@ const _removeViteModuleLoader = (html: string) => {
 	// Graceful fallback if Vite updates the format of their module loader in the future.
 	if (!match || match.length < 3) return html
 	return html.replace(match[1], '  <script type="module">').replace(match[2], "")
+}
+
+/**
+ * Modifies the Vite build config to make this plugin work well.
+ */
+const _useRecommendedBuildConfig = (config: UserConfig) => {
+	if (!config.build) config.build = {}
+	// Ensures that even very large assets are inlined in your JavaScript.
+	config.build.assetsInlineLimit = 100000000
+	// Avoid warnings about large chunks.
+	config.build.chunkSizeWarningLimit = 100000000
+	// Emit all CSS as a single file, which `vite-plugin-singlefile` can then inline.
+	config.build.cssCodeSplit = false
+	// Avoids the extra step of testing Brotli compression, which isn't really pertinent to a file served locally.
+	config.build.reportCompressedSize = false
+
+	if (!config.build.rollupOptions) config.build.rollupOptions = {}
+	if (!config.build.rollupOptions.output) config.build.rollupOptions.output = {}
+
+	const updateOutputOptions = (out: OutputOptions) => {
+		// Ensure that as many resources as possible are inlined.
+		out.inlineDynamicImports = true
+		// The `manualChunks` option became necessary somewhere around Vite 2.0 release to prevent the creation of a separate `vendor.js` bundle.
+		// The filename you choose for `manualChunks` ultimately doesn't matter, it will get rolled into `index.html` by the plugin.`outputOptions` became just `output` some time after that.
+		// This is _apparently_ [not needed](https://github.com/vitejs/vite/discussions/2462#discussioncomment-2444172) as of Vite 2.9, but I'm leaving it here for now in case folks are still using older versions of Vite.
+		out.manualChunks = () => "everything.js"
+	}
+
+	if (!Array.isArray(config.build.rollupOptions.output)) {
+		updateOutputOptions(config.build.rollupOptions.output)
+	} else {
+		config.build.rollupOptions.output.forEach(updateOutputOptions)
+	}
 }


### PR DESCRIPTION
Fixes #20 with updated config.

By making the recommended build config applied by default, we can greatly simplify the setup for new users. This also makes the docs cleaner and hide the implementation details.

I kept the comments reasoning about the build config in the code.

Also improved docs of the config types, adding support for auto-completion in most modern editors.