### PR TITLE
remove the `preloadMarker` "__VITE_PRELOAD__"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,9 @@ export function viteSingleFile({ useRecommendedBuildConfig = true, removeViteMod
 					const a = value as OutputAsset
 					if (o.code) {
 						const reScript = new RegExp(`<script type="module"[^>]*?src="[\./]*${o.fileName}"[^>]*?></script>`)
-						const code = `<script type="module">\n//${o.fileName}\n${o.code}\n</script>`
+						const preloadMarker = '"__VITE_PRELOAD__"'
+						const codeRaw = o.code.replace(preloadMarker, 'void 0')
+						const code = `<script type="module">\n//${o.fileName}\n${codeRaw}\n</script>`
 						const inlined = html.replace(reScript, (_) => code)
 						html = removeViteModuleLoader ? _removeViteModuleLoader(inlined) : inlined
 					} else if (a.fileName.endsWith(".css")) {


### PR DESCRIPTION
![screenshot-20220606-202356](https://user-images.githubusercontent.com/956693/172161319-106171fc-3a95-47e4-9417-aa22bbdf2cf6.png)
The preload marker can cause the code crash.