### PR TITLE
Bugfix when using import with '?url&worker' suffix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,9 @@ export function viteSingleFile({ useRecommendedBuildConfig = true, removeViteMod
 					if (!inlinePattern.length || micromatch.isMatch(jsName, inlinePattern)) {
 						const jsChunk = bundle[jsName] as OutputChunk
 						bundlesToDelete.push(jsName)
-						replacedHtml = replaceScript(replacedHtml, jsChunk.fileName, jsChunk.code, removeViteModuleLoader)
+						if (jsChunk.code != null) {
+							replacedHtml = replaceScript(replacedHtml, jsChunk.fileName, jsChunk.code, removeViteModuleLoader)
+						}
 					} else {
 						warnNotInlined(jsName)
 					}


### PR DESCRIPTION
First, thank you for your great work on this plugin!

vite-plugin-singlefile crashes with error message "[vite:singlefile] Cannot read properties of undefined (reading 'replace')" when you are importing a TypeScript file with the additional mode "?url&worker", as described here: https://vitejs.dev/guide/assets.html#importing-asset-as-url

This patch fixes this crash and makes it possible to inline JavaScript chunks, while skipping files that are explicitly marked as being required as a separate file.

To reproduce the bug:

Create a new project using "npm init vite" and select "svelte" and "typescript".

Then in vite.config.js:
```typescript
import { defineConfig } from 'vite'
import { svelte } from '@sveltejs/vite-plugin-svelte'
import { viteSingleFile } from 'vite-plugin-singlefile'

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [svelte(), viteSingleFile()]
})
```

Add a file "serviceworker.ts" to the "src" directory:

```typescript
export default function foo() {
  console.log('Hello')
}
```

And add this import to App.svelte:

```typescript
  import serviceWorkerUrl from "./serviceworker.ts?url&worker";
```

Now run "npm run build" and you will receive this output:

```bash
npm run build

> svelte-vite-singlefile-bug-repro@0.0.0 build
> vite build

vite v3.0.4 building for production...
✓ 1 modules transformed.
Generated an empty chunk: "serviceworker"
✓ 10 modules transformed.
rendering chunks (1)...[vite:singlefile] Cannot read properties of undefined (reading 'replace')
error during build:
TypeError: Cannot read properties of undefined (reading 'replace')
    at replaceScript (file:///home/daniel/projects/svelte-vite-singlefile-bug-repro/node_modules/vite-plugin-singlefile/dist/esm/index.js:6:32)
    at Object.generateBundle (file:///home/daniel/projects/svelte-vite-singlefile-bug-repro/node_modules/vite-plugin-singlefile/dist/esm/index.js:34:40)
    at file:///home/daniel/projects/svelte-vite-singlefile-bug-repro/node_modules/rollup/dist/es/shared/rollup.js:22695:37
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```