### PR TITLE
Remove deprecated `type` attribute in `<style>`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export function replaceScript(html: string, scriptFilename: string, scriptCode: 
 
 export function replaceCss(html: string, scriptFilename: string, scriptCode: string): string {
 	const reCss = new RegExp(`<link[^>]*? href="[./]*${scriptFilename}"[^>]*?>`)
-	const inlined = html.replace(reCss, `<style type="text/css">\n${scriptCode}\n</style>`)
+	const inlined = html.replace(reCss, `<style>\n${scriptCode}\n</style>`)
 	return inlined
 }
 


### PR DESCRIPTION
Per [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/style#attr-type), the `type` attribute on `<style>` is deprecated and no longer needed. Given Vite targets modern browsers by default, we can safely remove it.