### PR TITLE
Adds new deleteInlinedFiles setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Defaults to `[]`, which will inline all recognized JavaScript and CSS assets. Yo
 array of "glob" patterns to limit the inlining to certain assets. Any assets missed by your patterns will
 generate a warning (same as any unrecognized assets).
 
+### deleteInlinedFiles
+
+Defaults to `true`, which deletes all inlined files that were inlined. A use case for turning this to `false` would be if you would like sourcemaps to be generated so you can upload them to an error tracking platform like Sentry.io.
+
 ### Caveats
 
 - `favicon` resources are not inlined by Vite, and this plugin doesn't do that either.


### PR DESCRIPTION
Hi @richardtallent! Here's a quick PR to add support for allowing the user to choose whether or not to delete the inlined files. In my case, I need to skip deleting the inlined files so source maps can be generated for them and uploaded to Sentry.
I updated the README to explain the new setting and defaulted it to true to keep the existing functionality the same. Thank you for the great plugin!