### PR TITLE
Replace `replaceAll()` to support Node.JS v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
 	"files": [
 		"dist"
 	],
+	"engines": {
+		"node": "^14.18.0 || >=16.0.0"
+	},
 	"scripts": {
 		"dev": "rimraf dist && tsc -w --p tsconfig.json",
 		"build": "rimraf dist && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,9 @@ const defaultConfig = { useRecommendedBuildConfig: true, removeViteModuleLoader:
 
 export function replaceScript(html: string, scriptFilename: string, scriptCode: string, removeViteModuleLoader = false): string {
 	const reScript = new RegExp(`<script([^>]*?) src="[./]*${scriptFilename}"([^>]*)></script>`)
-	const preloadMarker = '"__VITE_PRELOAD__"'
-	const newCode = scriptCode.replaceAll(preloadMarker, "void 0")
+	// we can't use String.prototype.replaceAll since it isn't supported in Node.JS 14
+	const preloadMarker = /"__VITE_PRELOAD__"/g
+	const newCode = scriptCode.replace(preloadMarker, "void 0")
 	const inlined = html.replace(reScript, (_, beforeSrc, afterSrc) => `<script${beforeSrc}${afterSrc}>\n${newCode}\n</script>`)
 	return removeViteModuleLoader ? _removeViteModuleLoader(inlined) : inlined
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -7,7 +7,9 @@
 		"declarationMap": false,
 		"esModuleInterop": true,
 		"inlineSourceMap": false,
-		"lib": ["esnext", "dom"],
+		// es2020 is what Node.JS v14 supports
+		// see https://github.com/tsconfig/bases/blob/main/bases/node14.json
+		"lib": ["es2020", "dom"],
 		"listEmittedFiles": false,
 		"moduleResolution": "node",
 		"noUnusedLocals": true,


### PR DESCRIPTION
`String.prototype.replaceAll()` was only added in Node.JS v15, and so doesn't work in Node.JS v14, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll

However, it is easy to replace with a Regex that has the `/g` (global) flag enabled for Node.JS v14 support.

Additionally, I modified your `tsconfig-base.json` so that it copies the recommended `lib: [es2020]` for Node.JS v14, see https://github.com/tsconfig/bases/blob/main/bases/node14.json
This means that TypeScript will throw an error if a non-supported function is used, like `replaceAll()`.

I've also updated the `engines.node` field in the `package.json` so that it matches that one that Vite v3 has, see https://github.com/vitejs/vite/blob/9c808cdec89b807bff33eef37dfbb03557291ec1/packages/vite/package.json#L33-L35