### PR TITLE
ci: fix CI for Node v14 by updating npm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
+      - name: Update NPM to >7
+        if: ${{ matrix.node }} == '14'
+        # old version of npms don't automatically install peerDependencies
+        run: npm install -g npm@9
       - run: npm ci # throws an error if package-lock.json is out-of-date
       - run: npm run lint
       - run: npm test
@@ -45,6 +49,10 @@ jobs:
           cache-dependency-path: |
             vite-plugin-singlefile/package-lock.json
             vite-plugin-singlefile-example/package-lock.json
+      - name: Update NPM to >7
+        if: ${{ matrix.node }} == '14'
+        # old version of npms don't automatically install peerDependencies
+        run: npm install -g npm@9
       - # build and install dependencies for the vite-plugin-singlefile package
         run: npm ci
         working-directory: vite-plugin-singlefile


### PR DESCRIPTION
It looks like I was wrong about https://github.com/richardtallent/vite-plugin-singlefile/pull/64#discussion_r1019713613 (my fault, I should have tested it), the CI didn't actually work in Node v14 due to a different reason:

NPM versions before 7 do not automatically install `"peerDependencies"` when running `npm install` locally, so do not work with this repo (this behaviour is also the default for `yarn`)

Because the GitHub `actions/setup-node@v3` comes with NPM v6 for Node v14, this means we need to manually upgrade to NPM@>=7 for CI to run.

## Design Decisions

It's also possible to fix this issue by copying your `"peerDependencies"` to `"devDependencies"`, to support `npm@6` and `yarn`, but considering they're only needed for local/development installs, it's probably not worth the effort to support them!