### PR TITLE
Include beforeSrc/afterSrc attributes in replaceCss

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,8 @@ export function replaceScript(html: string, scriptFilename: string, scriptCode: 
 }
 
 export function replaceCss(html: string, scriptFilename: string, scriptCode: string): string {
-	const reCss = new RegExp(`<link[^>]*? href="[./]*${scriptFilename}"[^>]*?>`)
-	const inlined = html.replace(reCss, `<style>\n${scriptCode}\n</style>`)
+	const reStyle = new RegExp(`<link([^>]*?) href="[./]*${scriptFilename}"([^>]*?)>`)
+	const inlined = html.replace(reStyle, (_, beforeSrc, afterSrc) => `<style${beforeSrc}${afterSrc}>\n${scriptCode}\n</style>`);
 	return inlined
 }
 


### PR DESCRIPTION
Includes other attributes when swapping a <link> to a <style>. EG:

```html
    <link rel="stylesheet" data-cache-id="123" href="/assets/style.css"> 
    <!-- Becomes: -->
    <style data-cahe-id="123">...</style>
```

May not be too useful for too many cases, but it's consistent with the `<script>` tag handling, and useful in my case!