### PR TITLE
Introduce a config option for collapsing newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,15 @@ generate a warning (same as any unrecognized assets).
 
 ### deleteInlinedFiles
 
-Defaults to `true`, which deletes all inlined files that were inlined. A use case for turning this to `false` would be if you would like sourcemaps to be generated so you can upload them to an error tracking platform like Sentry.io.
+Defaults to `true`, which deletes all inlined files that were inlined. A use case for turning this
+to `false` would be if you would like sourcemaps to be generated so you can upload them to an error
+tracking platform like Sentry.io.
+
+### collapseNewlines
+
+Defaults to `false`. `vite-plugin-singlefile` will inline assets in the `generateBundle` stage, during
+which it is too late to run any code minification plugins; setting this to `true` will trim leading
+and trailing newlines inserted while combining resources in a single file.
 
 ### Caveats
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vite-plugin-singlefile",
-	"version": "0.13.3",
+	"version": "0.13.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vite-plugin-singlefile",
-			"version": "0.13.3",
+			"version": "0.13.5",
 			"license": "MIT",
 			"dependencies": {
 				"micromatch": "^4.0.5"


### PR DESCRIPTION
This commit introduces a config option that, when enabled, collapses leading and trailing newlines inserted while combining assets within a single file.

This is necessary because, by the time this plugin runs (i.e. during the `generateBundle` stage), it is too late to perform any code minification.