### PR TITLE
Fix: use relative base path to support static resources in public folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Defaults to `true`, which deletes all inlined files that were inlined. A use cas
 
 ### Caveats
 
-- `favicon` resources are not inlined by Vite, and this plugin doesn't do that either.
+- Static resources in `public` folder (like `favicon`) are not inlined by Vite, and this plugin doesn't do that either. BUT the output single HTML file CAN work together with these resouces, using relative paths.
 - Inlining of SVG isn't supported directly by Vite, so it isn't supported directly here either. You'll need to use something like `https://github.com/jpkleemans/vite-svg-loader`, or put your SVG directly into the template.
 - There may be other situations where referenced files aren't inlined by Vite and aren't caught by this plugin either.
 - This is my first Vite and first Rollup plugin. I have no idea what I'm doing. PRs welcome.

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,8 +113,12 @@ const _useRecommendedBuildConfig = (config: UserConfig) => {
 	config.build.chunkSizeWarningLimit = 100000000
 	// Emit all CSS as a single file, which `vite-plugin-singlefile` can then inline.
 	config.build.cssCodeSplit = false
-	// Subfolder bases are not supported, and shouldn't be needed because we're embedding everything.
-	config.base = undefined
+	// We need relative path to support any static files in public folder,
+	// which are copied to ${build.outDir} by vite.
+	config.base = './'
+	// Make generated files in ${build.outDir}'s root, instead of default ${build.outDir}/assets.
+	// Then the embedded resources can be loaded by relative path.
+    config.build.assetsDir = ''
 
 	if (!config.build.rollupOptions) config.build.rollupOptions = {}
 	if (!config.build.rollupOptions.output) config.build.rollupOptions.output = {}


### PR DESCRIPTION
Fix #69 . Assets in public folder are copied to ${build.outDir} by vite and not inlined by this plugin. 

We **CAN** work with them, however, using relative path and place all resources in the same folder.

Changes of recommended build config:
1. Set `config.base` to `'./'` to enable relative path.
2. Set `config.build.assetsDir` to `''` to make generated files in ${build.outDir}'s root, instead of default ${build.outDir}/assets. Then the embedded resources can be loaded by relative path.

I also updated README to inform this in `Caveats`.
