### PR TITLE
Fix __VITE_PRELOAD__ regression in vite 5.3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const defaultConfig = { useRecommendedBuildConfig: true, removeViteModuleLoader:
 export function replaceScript(html: string, scriptFilename: string, scriptCode: string, removeViteModuleLoader = false): string {
 	const reScript = new RegExp(`<script([^>]*?) src="[./]*${scriptFilename}"([^>]*)></script>`)
 	// we can't use String.prototype.replaceAll since it isn't supported in Node.JS 14
-	const preloadMarker = /"__VITE_PRELOAD__"/g
+	const preloadMarker = /"?__VITE_PRELOAD__"?/g
 	const newCode = scriptCode.replace(preloadMarker, "void 0")
 	const inlined = html.replace(reScript, (_, beforeSrc, afterSrc) => `<script${beforeSrc}${afterSrc}>${newCode}</script>`)
 	return removeViteModuleLoader ? _removeViteModuleLoader(inlined) : inlined


### PR DESCRIPTION
The `"__VITE_PRELOAD__"` replacement no longer works in vite 5.3 because of this change: https://github.com/vitejs/vite/pull/16562

The reason is that the produced marker is just `__VITE_PRELOAD__`, no quotes.

I updated the regex to support both versions, by taking the quote as an optional pattern.

Tested both vite 5.3 and vite 5.2.12, working fine.