### PR TITLE
[FIX] escape closing script tag and opening comment tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const defaultConfig = { useRecommendedBuildConfig: true, removeViteModuleLoader:
 export function replaceScript(html: string, scriptFilename: string, scriptCode: string, removeViteModuleLoader = false): string {
 	const reScript = new RegExp(`<script([^>]*?) src="[./]*${scriptFilename}"([^>]*)></script>`)
 	const preloadMarker = /"?__VITE_PRELOAD__"?/g
-	const newCode = scriptCode.replace(preloadMarker, "void 0")
+	const newCode = scriptCode.replace(preloadMarker, "void 0").replace(/(<)(\/script>|!--)/g, '\\x3C$2')
 	const inlined = html.replace(reScript, (_, beforeSrc, afterSrc) => `<script${beforeSrc}${afterSrc}>${newCode}</script>`)
 	return removeViteModuleLoader ? _removeViteModuleLoader(inlined) : inlined
 }


### PR DESCRIPTION
There was an issue when the javascript code contains `</script>` or `<!--`, it was interpreted has HTML code and broke the inlined HTML file.