### PR TITLE
Respect `logLevel`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,17 +49,13 @@ export function viteSingleFile({
 	inlinePattern = [],
 	deleteInlinedFiles = true,
 }: Config = defaultConfig): PluginOption {
-
-	function warnNotInlined(filename: string) {
-		console.debug(`NOTE: asset not inlined: ${filename}`)
-	}
-
 	return {
 		name: "vite:singlefile",
 		config: useRecommendedBuildConfig ? _useRecommendedBuildConfig : undefined,
 		enforce: "post",
-		generateBundle: (_, bundle) => {
-			console.debug("\n")
+		generateBundle(_, bundle) {
+			const warnNotInlined = ( filename: string ) => this.info( `NOTE: asset not inlined: ${ filename }` )
+			this.info("\n")
 			const files = {
 				html: [] as string[],
 				css: [] as string[],
@@ -88,7 +84,7 @@ export function viteSingleFile({
 					}
 					const jsChunk = bundle[filename] as OutputChunk
 					if (jsChunk.code != null) {
-						console.debug(`Inlining: ${filename}`)
+						this.info(`Inlining: ${filename}`)
 						bundlesToDelete.push(filename)
 						replacedHtml = replaceScript(replacedHtml, jsChunk.fileName, jsChunk.code, removeViteModuleLoader)
 					}
@@ -99,7 +95,7 @@ export function viteSingleFile({
 						continue
 					}
 					const cssChunk = bundle[filename] as OutputAsset
-					console.debug(`Inlining: ${filename}`)
+					this.info(`Inlining: ${filename}`)
 					bundlesToDelete.push(filename)
 					replacedHtml = replaceCss(replacedHtml, cssChunk.fileName, cssChunk.source as string)
 				}


### PR DESCRIPTION
I have a script that runs Vite dozens of times and I only want it to log messages when I change the `logLevel`. However, this plugin always logs messages to the console, regardless of the [`logLevel` configuration option](https://vite.dev/config/shared-options.html#loglevel) in Vite.

This can be easily fixed by using the `this.debug()`, `this.info()`, `this.warn()`, and `this.error()` helpers. I used `this.info()` instead of `this.debug()` because the lowest level that Vite accepts via configuration is `info` (see [`logLevel`](https://vite.dev/config/shared-options.html#loglevel)).
