### PR TITLE
feat: add inline web worker support

### DIFF
--- a/__tests__/replaceWorker.spec.ts
+++ b/__tests__/replaceWorker.spec.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from "vitest"
+import { replaceWorker } from "../dist/esm/index.js"
+
+describe("Replace Worker", () => {
+	test("It should inline worker scripts using Blob URLs", () => {
+		const workerCode = `self.onmessage = function(e) { postMessage(e.data * 2); }`
+		const jsCode = `const worker = new Worker(new URL("./my-worker.js", import.meta.url));`
+		const result = replaceWorker(jsCode, "my-worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).toContain("new Blob")
+		expect(result).toContain("application/javascript")
+		expect(result).not.toContain("import.meta.url")
+	})
+
+	test("It should handle Vite's complex worker URL pattern", () => {
+		const workerCode = `(function(){"use strict";self.onmessage=function(s){const{num:t}=s.data,e=t*2;self.postMessage({result:e})}})();`
+		const jsCode = `new Worker(new URL(""+new URL("compute.worker-CwirOBec.js",import.meta.url).href,import.meta.url),{type:"module"})`
+		const result = replaceWorker(jsCode, "compute.worker-CwirOBec.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).toContain("new Blob")
+		expect(result).not.toContain("import.meta.url")
+		expect(result).not.toContain("module")
+	})
+
+	test("It should remove type:module from Worker constructor when inlining", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `new Worker(new URL("./worker.js", import.meta.url), {type: "module"})`
+		const result = replaceWorker(jsCode, "worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).not.toContain('"module"')
+		expect(result).toMatch(/new Worker\(URL\.createObjectURL\(new Blob\(\[.*\],\{type:"application\/javascript"\}\)\)\)$/)
+	})
+
+	test("It should handle worker filenames with dots", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `new Worker(new URL("./my.worker.js", import.meta.url))`
+		const result = replaceWorker(jsCode, "my.worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).not.toContain("import.meta.url")
+	})
+
+	test("It should handle worker filenames without leading ./", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `new Worker(new URL("worker.js", import.meta.url))`
+		const result = replaceWorker(jsCode, "worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).not.toContain("import.meta.url")
+	})
+
+	test("It should handle single quotes in the URL constructor", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `new Worker(new URL('./my-worker.js', import.meta.url))`
+		const result = replaceWorker(jsCode, "my-worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).not.toContain("import.meta.url")
+	})
+
+	test("It should escape special characters in worker code", () => {
+		const workerCode = `const msg = "Hello\\nWorld"; // Comment\nconst x = 1;`
+		const jsCode = `new Worker(new URL("./worker.js", import.meta.url))`
+		const result = replaceWorker(jsCode, "worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).toContain("\\\\n")
+		expect(result).toContain('\\"')
+	})
+
+	test("It should replace multiple occurrences of the same worker", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `
+			const w1 = new Worker(new URL("./worker.js", import.meta.url));
+			const w2 = new Worker(new URL("./worker.js", import.meta.url));
+		`
+		const result = replaceWorker(jsCode, "worker.js", workerCode)
+		const matches = result.match(/URL\.createObjectURL/g)
+		expect(matches).toHaveLength(2)
+	})
+
+	test("It should not modify code that doesn't reference the worker", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `new Worker(new URL("./other-worker.js", import.meta.url))`
+		const result = replaceWorker(jsCode, "worker.js", workerCode)
+		expect(result).toEqual(jsCode)
+	})
+
+	test("It should handle workers with leading slash", () => {
+		const workerCode = `console.log("worker");`
+		const jsCode = `new Worker(new URL("/worker.js", import.meta.url))`
+		const result = replaceWorker(jsCode, "worker.js", workerCode)
+		expect(result).toContain("URL.createObjectURL")
+		expect(result).not.toContain("import.meta.url")
+	})
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vite-plugin-singlefile",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vite-plugin-singlefile",
-			"version": "2.2.1",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"micromatch": "^4.0.8"
@@ -30,7 +30,7 @@
 			},
 			"peerDependencies": {
 				"rollup": "^4.44.1",
-				"vite": "^7.0.0"
+				"vite": "^5.4.11 || ^6.0.0 || ^7.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,14 @@ export type Config = {
 	// object here. For example, use `{ base: "/" }` to override the default "./" base path for
 	// non-inlined public files.
 	overrideConfig?: Partial<UserConfig>
+	// Inline web worker scripts as Blob URLs. When enabled, worker files are embedded directly
+	// into the JavaScript code that creates them, using Blob URLs instead of separate files.
+	//
+	// @default true
+	inlineWorkers?: boolean
 }
 
-const defaultConfig = { useRecommendedBuildConfig: true, removeViteModuleLoader: false, deleteInlinedFiles: true }
+const defaultConfig = { useRecommendedBuildConfig: true, removeViteModuleLoader: false, deleteInlinedFiles: true, inlineWorkers: true }
 
 export function replaceScript(html: string, scriptFilename: string, scriptCode: string, removeViteModuleLoader = false): string {
 	const f = scriptFilename.replaceAll(".", "\\.")
@@ -45,9 +50,43 @@ export function replaceCss(html: string, scriptFilename: string, scriptCode: str
 	return inlined
 }
 
+// Replaces worker file URLs in JavaScript code with inline Blob URLs.
+// This handles patterns like:
+//   - new URL("./worker.js", import.meta.url)
+//   - new URL(""+new URL("worker.js",import.meta.url).href,import.meta.url) (Vite's transformed pattern)
+// and transforms them to: URL.createObjectURL(new Blob([...], {type: "application/javascript"}))
+// Also removes {type: "module"} from Worker constructor since Blob URLs don't work with module workers.
+export function replaceWorker(jsCode: string, workerFilename: string, workerCode: string): string {
+	const escapedFilename = workerFilename.replaceAll(".", "\\.").replaceAll("/", "\\/")
+	const escapedWorkerCode = workerCode.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")
+	const blobUrlCode = `URL.createObjectURL(new Blob(["${escapedWorkerCode}"],{type:"application/javascript"}))`
+	let result = jsCode
+
+	// Pattern 1: Vite's complex pattern - new URL(""+new URL("worker.js",import.meta.url).href,import.meta.url)
+	const reViteWorkerUrl = new RegExp(
+		`new\\s+URL\\s*\\(\\s*["']\\s*["']\\s*\\+\\s*new\\s+URL\\s*\\(\\s*["'](?:\\.\\/|\\/)?(${escapedFilename})["']\\s*,\\s*import\\.meta\\.url\\s*\\)\\.href\\s*,\\s*import\\.meta\\.url\\s*\\)`,
+		"g"
+	)
+	result = result.replace(reViteWorkerUrl, blobUrlCode)
+
+	// Pattern 2: Simple pattern - new URL("./worker.js", import.meta.url)
+	const reSimpleWorkerUrl = new RegExp(`new\\s+URL\\s*\\(\\s*["'](?:\\.\\/|\\/)?(${escapedFilename})["']\\s*,\\s*import\\.meta\\.url\\s*\\)`, "g")
+	result = result.replace(reSimpleWorkerUrl, blobUrlCode)
+
+	// Remove {type:"module"} or {type: "module"} from Worker constructors that use Blob URL
+	// Vite bundles workers as IIFEs, so they don't need to be modules
+	result = result.replace(
+		/new\s+Worker\s*\(\s*(URL\.createObjectURL\(new\s+Blob\(\[[^\]]+\],\{type:"application\/javascript"\}\)\))\s*,\s*\{\s*type\s*:\s*["']module["']\s*\}\s*\)/g,
+		"new Worker($1)"
+	)
+
+	return result
+}
+
 const isJsFile = /\.[mc]?js$/
 const isCssFile = /\.css$/
 const isHtmlFile = /\.html?$/
+const isWorkerFile = /[-.]worker[-.][\w-]*\.[mc]?js$/
 
 export function viteSingleFile({
 	useRecommendedBuildConfig = true,
@@ -55,6 +94,7 @@ export function viteSingleFile({
 	inlinePattern = [],
 	deleteInlinedFiles = true,
 	overrideConfig = {},
+	inlineWorkers = true,
 }: Config = defaultConfig): PluginOption {
 	// Modifies the Vite build config to make this plugin work well.
 	const _useRecommendedBuildConfig = (config: UserConfig) => {
@@ -100,6 +140,7 @@ export function viteSingleFile({
 				html: [] as string[],
 				css: [] as string[],
 				js: [] as string[],
+				worker: [] as string[],
 				other: [] as string[],
 			}
 			for (const i of Object.keys(bundle)) {
@@ -107,6 +148,8 @@ export function viteSingleFile({
 					files.html.push(i)
 				} else if (isCssFile.test(i)) {
 					files.css.push(i)
+				} else if (isWorkerFile.test(i)) {
+					files.worker.push(i)
 				} else if (isJsFile.test(i)) {
 					files.js.push(i)
 				} else {
@@ -114,6 +157,33 @@ export function viteSingleFile({
 				}
 			}
 			const bundlesToDelete = [] as string[]
+
+			if (inlineWorkers) {
+				for (const workerFilename of files.worker) {
+					if (inlinePattern.length && !micromatch.isMatch(workerFilename, inlinePattern)) {
+						warnNotInlined(workerFilename)
+						continue
+					}
+					const workerChunk = bundle[workerFilename]
+					const workerCode = workerChunk.type === "chunk" ? workerChunk.code : ((workerChunk as OutputAsset).source as string)
+					if (workerCode != null) {
+						for (const jsFilename of files.js) {
+							const jsChunk = bundle[jsFilename] as OutputChunk
+							if (jsChunk.code != null) {
+								const updatedCode = replaceWorker(jsChunk.code, workerChunk.fileName, workerCode)
+								if (updatedCode !== jsChunk.code) {
+									this.info(`Inlining worker: ${workerFilename} into ${jsFilename}`)
+									jsChunk.code = updatedCode
+									if (!bundlesToDelete.includes(workerFilename)) {
+										bundlesToDelete.push(workerFilename)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
 			for (const name of files.html) {
 				const htmlChunk = bundle[name] as OutputAsset
 				let replacedHtml = htmlChunk.source as string


### PR DESCRIPTION
- Add inlineWorkers option (enabled by default) to embed worker scripts as Blob URLs
- Add replaceWorker function to handle Vite's worker URL patterns
- Detect worker files matching *worker*.js pattern
- Remove {type: \"module\"} from Worker constructors since Blob URLs use IIFE format
- Add unit tests for replaceWorker function