### PR TITLE
Add Vite 8 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,11 @@
 			"peerDependencies": {
 				"rollup": "^4.44.1",
 				"vite": "^7.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,12 @@
 	},
 	"peerDependencies": {
 		"rollup": "^4.44.1",
-		"vite": "^5.4.11 || ^6.0.0 || ^7.0.0"
+		"vite": "^5.4.11 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+	},
+	"peerDependenciesMeta": {
+		"rollup": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,18 +72,34 @@ export function viteSingleFile({
 		// Then the embedded resources can be loaded by relative path.
 		config.build.assetsDir = ""
 
-		if (!config.build.rollupOptions) config.build.rollupOptions = {}
-		if (!config.build.rollupOptions.output) config.build.rollupOptions.output = {}
-
-		const updateOutputOptions = (out: OutputOptions) => {
-			// Ensure that as many resources as possible are inlined.
-			out.inlineDynamicImports = true
-		}
-
-		if (Array.isArray(config.build.rollupOptions.output)) {
-			for (const o of config.build.rollupOptions.output) updateOutputOptions(o as OutputOptions)
+		// Vite 8 uses Rolldown and sets up a getter proxy on build.rollupOptions before calling config hooks.
+		// Detect this to use the correct option: codeSplitting:false (Rolldown) vs inlineDynamicImports:true (Rollup).
+		const isVite8 = typeof Object.getOwnPropertyDescriptor(config.build, "rollupOptions")?.get === "function"
+		if (isVite8) {
+			const build = config.build as Record<string, unknown>
+			build.rolldownOptions ??= {}
+			const rolldownOptions = build.rolldownOptions as Record<string, unknown>
+			rolldownOptions.output ??= {}
+			const out = rolldownOptions.output as Record<string, unknown>[]
+			if (Array.isArray(out)) {
+				for (const o of out) o.codeSplitting = false
+			} else {
+				;(out as Record<string, unknown>).codeSplitting = false
+			}
 		} else {
-			updateOutputOptions(config.build.rollupOptions.output as OutputOptions)
+			if (!config.build.rollupOptions) config.build.rollupOptions = {}
+			if (!config.build.rollupOptions.output) config.build.rollupOptions.output = {}
+
+			const updateOutputOptions = (out: OutputOptions) => {
+				// Ensure that as many resources as possible are inlined.
+				out.inlineDynamicImports = true
+			}
+
+			if (Array.isArray(config.build.rollupOptions.output)) {
+				for (const o of config.build.rollupOptions.output) updateOutputOptions(o as OutputOptions)
+			} else {
+				updateOutputOptions(config.build.rollupOptions.output as OutputOptions)
+			}
 		}
 
 		Object.assign(config, overrideConfig)


### PR DESCRIPTION
## Summary

Vite 8 switched from Rollup to [Rolldown](https://rolldown.rs/) under the hood,
which broke this plugin builds would either fail.

This PR adds compatibility with Vite 8 while maintaining full backward compatibility.

Closes #116

## Testing

Tested on a local [example project](https://github.com/richardtallent/vite-plugin-singlefile-example).
