### PR TITLE
Fix Vite 8 Rolldown compatibility

### DIFF
--- a/__tests__/fixtures/vite-app/index.html
+++ b/__tests__/fixtures/vite-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>vite-plugin-singlefile fixture</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/main.js"></script>
+	</body>
+</html>

--- a/__tests__/fixtures/vite-app/src/lazy.js
+++ b/__tests__/fixtures/vite-app/src/lazy.js
@@ -1,0 +1,3 @@
+export function run() {
+	document.body.dataset.lazy = "lazy-loaded"
+}

--- a/__tests__/fixtures/vite-app/src/main.js
+++ b/__tests__/fixtures/vite-app/src/main.js
@@ -1,0 +1,6 @@
+import "./styles.css"
+
+document.getElementById("app").textContent = "main bundle"
+document.body.dataset.main = "ready"
+
+import("./lazy.js").then(({ run }) => run())

--- a/__tests__/fixtures/vite-app/src/styles.css
+++ b/__tests__/fixtures/vite-app/src/styles.css
@@ -1,0 +1,4 @@
+body {
+	background: rgb(1 2 3);
+	color: white;
+}

--- a/__tests__/replaceCss.spec.ts
+++ b/__tests__/replaceCss.spec.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from "vitest"
-import { replaceCss } from "../dist/esm/index.js"
+import { replaceCss } from "../src/index"
 
 describe("Replace Css", () => {
-  test('It should inline external css and preserve other script attributes', () => {
-    const outputStyle = `<style rel="stylesheet"></style>`
-    expect(replaceCss(`<link rel="stylesheet" href="./foo.css">`, "foo.css", "")).toEqual(outputStyle)
-    expect(replaceCss(`<link rel="stylesheet" href="https://www.base.dir/path/foo.css">`, "foo.css", "")).toEqual(outputStyle)
-  })
+	test("It should inline external css and preserve other script attributes", () => {
+		const outputStyle = `<style rel="stylesheet"></style>`
+		expect(replaceCss(`<link rel="stylesheet" href="./foo.css">`, "foo.css", "")).toEqual(outputStyle)
+		expect(replaceCss(`<link rel="stylesheet" href="https://www.base.dir/path/foo.css">`, "foo.css", "")).toEqual(outputStyle)
+	})
 })

--- a/__tests__/replaceScript.spec.ts
+++ b/__tests__/replaceScript.spec.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest"
-import { replaceScript } from "../dist/esm/index.js"
+import { replaceScript } from "../src/index"
 
 describe("Replace Script", () => {
 	test("It should inline external scripts and preserve other script attributes", () => {

--- a/__tests__/viteBuild.spec.ts
+++ b/__tests__/viteBuild.spec.ts
@@ -1,0 +1,57 @@
+import { cpSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { spawnSync } from "node:child_process"
+import { version as viteVersion } from "vite"
+import { afterEach, describe, expect, test } from "vitest"
+
+const repoRoot = process.cwd()
+const fixtureRoot = join(repoRoot, "__tests__", "fixtures", "vite-app")
+const viteBin = join(repoRoot, "node_modules", "vite", "bin", "vite.js")
+const tmpRoots: string[] = []
+
+const createFixtureApp = () => {
+	const root = mkdtempSync(join(repoRoot, ".tmp-vite-build-"))
+	tmpRoots.push(root)
+	cpSync(fixtureRoot, root, { recursive: true })
+	writeFileSync(
+		join(root, "vite.config.ts"),
+		`import { defineConfig } from "vite"
+import { viteSingleFile } from "../src/index.ts"
+
+export default defineConfig({
+	plugins: [viteSingleFile()],
+})
+`
+	)
+	return root
+}
+
+afterEach(() => {
+	for (const root of tmpRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true })
+	}
+})
+
+describe("viteSingleFile build integration", () => {
+	test("it produces a single HTML file without the Vite 8 deprecation warning", () => {
+		const root = createFixtureApp()
+		const result = spawnSync("node", [viteBin, "build"], {
+			cwd: root,
+			encoding: "utf8",
+		})
+		const output = `${result.stdout}${result.stderr}`
+
+		expect(result.status).toBe(0)
+		if (Number(viteVersion.split(".")[0]) >= 8) {
+			expect(output).not.toContain("inlineDynamicImports option is deprecated")
+		}
+
+		expect(readdirSync(join(root, "dist")).sort()).toEqual(["index.html"])
+
+		const html = readFileSync(join(root, "dist", "index.html"), "utf8")
+		expect(html).toContain("<style")
+		expect(html).toContain("lazy-loaded")
+		expect(html).not.toMatch(/<script[^>]+src=/)
+		expect(html).not.toMatch(/<link[^>]+href=.*\\.css/)
+	})
+})

--- a/__tests__/viteSingleFileConfig.spec.ts
+++ b/__tests__/viteSingleFileConfig.spec.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "vitest"
+import type { UserConfig } from "vite"
+import { viteSingleFile } from "../src/index"
+
+type InlineableOutputOptions = {
+	inlineDynamicImports?: boolean
+	codeSplitting?: boolean
+}
+
+type InlineableBuildOptions = NonNullable<UserConfig["build"]> & {
+	rolldownOptions?: {
+		output?: InlineableOutputOptions | InlineableOutputOptions[]
+	}
+}
+
+const applyRecommendedBuildConfig = (config: UserConfig) => {
+	const plugin = viteSingleFile() as { config?: (config: UserConfig) => void }
+	expect(plugin.config).toBeTypeOf("function")
+	plugin.config?.(config)
+}
+
+describe("viteSingleFile config", () => {
+	test("it configures Rollup output for Vite 5-7 style configs", () => {
+		const config: UserConfig = { build: {} }
+
+		applyRecommendedBuildConfig(config)
+
+		expect(config.base).toBe("./")
+		expect(config.build?.assetsDir).toBe("")
+		expect(config.build?.cssCodeSplit).toBe(false)
+		expect(config.build?.assetsInlineLimit?.()).toBe(true)
+		expect(config.build?.chunkSizeWarningLimit).toBe(100000000)
+		expect(config.build?.rollupOptions?.output).toMatchObject({ inlineDynamicImports: true })
+		expect((config.build as InlineableBuildOptions).rolldownOptions).toBeUndefined()
+	})
+
+	test("it configures Rolldown output for Vite 8 configs without touching the deprecated alias", () => {
+		const rolldownOptions = {} as NonNullable<InlineableBuildOptions["rolldownOptions"]>
+		const build = { rolldownOptions } as InlineableBuildOptions
+
+		Object.defineProperty(build, "rollupOptions", {
+			configurable: true,
+			enumerable: true,
+			get() {
+				return rolldownOptions
+			},
+			set() {
+				throw new Error("deprecated rollupOptions setter should not be used")
+			},
+		})
+
+		const config: UserConfig = { build }
+
+		applyRecommendedBuildConfig(config)
+
+		expect(build.rolldownOptions?.output).toMatchObject({ codeSplitting: false })
+		expect(build.rollupOptions).not.toHaveProperty("inlineDynamicImports")
+	})
+
+	test("it preserves output arrays when applying the Vite 8 workaround", () => {
+		const outputs: InlineableOutputOptions[] = [{}, {}]
+		const rolldownOptions = { output: outputs }
+		const build = { rolldownOptions } as InlineableBuildOptions
+
+		Object.defineProperty(build, "rollupOptions", {
+			configurable: true,
+			enumerable: true,
+			get() {
+				return rolldownOptions
+			},
+			set() {
+				throw new Error("deprecated rollupOptions setter should not be used")
+			},
+		})
+
+		applyRecommendedBuildConfig({ build })
+
+		expect(outputs).toEqual([{ codeSplitting: false }, { codeSplitting: false }])
+	})
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"eslint": "^9.39.4",
 				"globale": "^1.0.0",
 				"rimraf": "^6.0.1",
+				"rollup": "^4.59.0",
 				"typescript": "^5.8.3",
 				"vitest": "^4.1.0"
 			},
@@ -31,6 +32,11 @@
 			"peerDependencies": {
 				"rollup": "^4.59.0",
 				"vite": "^5.4.11 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -799,12 +805,12 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.59.0",
@@ -813,12 +819,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.59.0",
@@ -827,12 +833,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.59.0",
@@ -841,12 +847,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.59.0",
@@ -855,12 +861,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.59.0",
@@ -869,12 +875,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.59.0",
@@ -883,12 +889,12 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.59.0",
@@ -897,12 +903,12 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.59.0",
@@ -911,12 +917,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.59.0",
@@ -925,12 +931,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.59.0",
@@ -939,12 +945,12 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.59.0",
@@ -953,12 +959,12 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.59.0",
@@ -967,12 +973,12 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.59.0",
@@ -981,12 +987,12 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.59.0",
@@ -995,12 +1001,12 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.59.0",
@@ -1009,12 +1015,12 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.59.0",
@@ -1023,12 +1029,12 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.59.0",
@@ -1037,12 +1043,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.59.0",
@@ -1051,12 +1057,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.59.0",
@@ -1065,12 +1071,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.59.0",
@@ -1079,12 +1085,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openharmony"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.59.0",
@@ -1093,12 +1099,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.59.0",
@@ -1107,12 +1113,12 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.59.0",
@@ -1121,12 +1127,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.59.0",
@@ -1135,12 +1141,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.34.37",
@@ -1194,6 +1200,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -3550,8 +3557,8 @@
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -4789,176 +4796,176 @@
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
 			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-android-arm64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
 			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-darwin-arm64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
 			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-darwin-x64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
 			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-freebsd-arm64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
 			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-freebsd-x64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
 			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
 			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
 			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
 			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-arm64-musl": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
 			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
 			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-loong64-musl": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
 			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
 			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
 			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
 			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
 			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
 			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-x64-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
 			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-linux-x64-musl": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
 			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-openbsd-x64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
 			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-openharmony-arm64": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
 			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
 			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
 			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-win32-x64-gnu": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
 			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@rollup/rollup-win32-x64-msvc": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
 			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-			"optional": true,
-			"peer": true
+			"dev": true,
+			"optional": true
 		},
 		"@sinclair/typebox": {
 			"version": "0.34.37",
@@ -5006,7 +5013,8 @@
 		"@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.6",
@@ -6511,7 +6519,7 @@
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@rollup/rollup-android-arm-eabi": "4.59.0",
 				"@rollup/rollup-android-arm64": "4.59.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
 		"rollup": "^4.59.0",
 		"vite": "^5.4.11 || ^6.0.0 || ^7.0.0 || ^8.0.0"
 	},
+	"peerDependenciesMeta": {
+		"rollup": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.5",
 		"@eslint/js": "^9.39.4",
@@ -62,6 +67,7 @@
 		"@typescript-eslint/parser": "^8.35.1",
 		"eslint": "^9.39.4",
 		"globale": "^1.0.0",
+		"rollup": "^4.59.0",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3",
 		"vitest": "^4.1.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-// @ts-ignore
-import { UserConfig, PluginOption } from "vite"
-import { OutputChunk, OutputAsset, OutputOptions } from "rollup"
+// @ts-expect-error Vite's type entry is ESM-only under the current TS moduleResolution setting.
+import type { UserConfig, PluginOption } from "vite"
+import type { OutputChunk, OutputAsset, OutputBundle } from "rollup"
 import micromatch from "micromatch"
 
 export type Config = {
@@ -51,6 +51,33 @@ const isJsFile = /\.[mc]?js$/
 const isCssFile = /\.css$/
 const isHtmlFile = /\.html?$/
 
+type InlineableOutputOptions = {
+	inlineDynamicImports?: boolean
+	codeSplitting?: boolean
+}
+
+type InlineableBuildOptions = NonNullable<UserConfig["build"]> & {
+	rolldownOptions?: {
+		output?: InlineableOutputOptions | InlineableOutputOptions[]
+	}
+}
+
+const _isVite8Config = (build: InlineableBuildOptions) => typeof Object.getOwnPropertyDescriptor(build, "rollupOptions")?.get === "function"
+
+const _setOutputOption = (
+	output: InlineableOutputOptions | InlineableOutputOptions[] | undefined,
+	key: keyof InlineableOutputOptions,
+	value: boolean
+) => {
+	if (Array.isArray(output)) {
+		for (const item of output) item[key] = value
+		return output
+	}
+	const nextOutput = output ?? {}
+	nextOutput[key] = value
+	return nextOutput
+}
+
 export function viteSingleFile({
 	useRecommendedBuildConfig = true,
 	removeViteModuleLoader = false,
@@ -61,31 +88,32 @@ export function viteSingleFile({
 	// Modifies the Vite build config to make this plugin work well.
 	const _useRecommendedBuildConfig = (config: UserConfig) => {
 		if (!config.build) config.build = {}
+		const build = config.build as InlineableBuildOptions
 		// Ensures that even very large assets are inlined in your JavaScript.
-		config.build.assetsInlineLimit = () => true
+		build.assetsInlineLimit = () => true
 		// Avoid warnings about large chunks.
-		config.build.chunkSizeWarningLimit = 100000000
+		build.chunkSizeWarningLimit = 100000000
 		// Emit all CSS as a single file, which `vite-plugin-singlefile` can then inline.
-		config.build.cssCodeSplit = false
+		build.cssCodeSplit = false
 		// We need relative path to support any static files in public folder,
 		// which are copied to ${build.outDir} by vite.
 		config.base = "./"
 		// Make generated files in ${build.outDir}'s root, instead of default ${build.outDir}/assets.
 		// Then the embedded resources can be loaded by relative path.
-		config.build.assetsDir = ""
+		build.assetsDir = ""
 
-		if (!config.build.rollupOptions) config.build.rollupOptions = {}
-		if (!config.build.rollupOptions.output) config.build.rollupOptions.output = {}
-
-		const updateOutputOptions = (out: OutputOptions) => {
-			// Ensure that as many resources as possible are inlined.
-			out.inlineDynamicImports = true
-		}
-
-		if (Array.isArray(config.build.rollupOptions.output)) {
-			for (const o of config.build.rollupOptions.output) updateOutputOptions(o as OutputOptions)
+		// Vite 8 exposes `build.rollupOptions` as a deprecated alias backed by a getter
+		// and expects `build.rolldownOptions.output.codeSplitting = false` instead.
+		if (_isVite8Config(build)) {
+			build.rolldownOptions ??= {}
+			build.rolldownOptions.output = _setOutputOption(build.rolldownOptions.output, "codeSplitting", false)
 		} else {
-			updateOutputOptions(config.build.rollupOptions.output as OutputOptions)
+			build.rollupOptions ??= {}
+			build.rollupOptions.output = _setOutputOption(
+				build.rollupOptions.output as InlineableOutputOptions | InlineableOutputOptions[] | undefined,
+				"inlineDynamicImports",
+				true
+			)
 		}
 
 		Object.assign(config, overrideConfig)
@@ -95,7 +123,7 @@ export function viteSingleFile({
 		name: "vite:singlefile",
 		config: useRecommendedBuildConfig ? _useRecommendedBuildConfig : undefined,
 		enforce: "post",
-		generateBundle(_options: any, bundle: any) {
+		generateBundle(_options: unknown, bundle: OutputBundle) {
 			const warnNotInlined = (filename: string) => this.info(`NOTE: asset not inlined: ${filename}`)
 			this.info("\n")
 			const files = {

--- a/test-vite-versions.sh
+++ b/test-vite-versions.sh
@@ -1,21 +1,83 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 VITE_VERSIONS=("5.4.11" "6.0.0" "7.0.0" "8.0.0")
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURE_DIR="$ROOT_DIR/__tests__/fixtures/vite-app"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vite-plugin-singlefile-XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Building package tarball..."
+npm run build >/dev/null
+PACKAGE_FILE="$(npm pack --pack-destination "$TMP_DIR" | tail -n 1)"
+PACKAGE_TGZ="$TMP_DIR/$PACKAGE_FILE"
 
 echo "Testing against multiple Vite versions..."
 
 for version in "${VITE_VERSIONS[@]}"; do
-  echo ""
-  echo "=========================================="
-  echo "Testing with Vite $version..."
-  echo "=========================================="
-  npm install vite@"$version" --no-save --legacy-peer-deps
-  npm test
-  if [ $? -ne 0 ]; then
-    echo "Tests failed for Vite $version"
-    exit 1
-  fi
+	echo ""
+	echo "=========================================="
+	echo "Testing with Vite $version..."
+	echo "=========================================="
+
+	APP_DIR="$TMP_DIR/app-$version"
+	mkdir -p "$APP_DIR"
+	cp -R "$FIXTURE_DIR"/. "$APP_DIR"/
+
+	cat > "$APP_DIR/package.json" <<'EOF'
+{
+	"name": "vite-plugin-singlefile-matrix",
+	"private": true,
+	"type": "module"
+}
+EOF
+
+	cat > "$APP_DIR/vite.config.ts" <<'EOF'
+import { defineConfig } from "vite"
+import { viteSingleFile } from "vite-plugin-singlefile"
+
+export default defineConfig({
+	plugins: [viteSingleFile()],
+})
+EOF
+
+	pushd "$APP_DIR" >/dev/null
+	npm install "vite@$version" "$PACKAGE_TGZ" --silent
+	BUILD_OUTPUT="$(node ./node_modules/vite/bin/vite.js build 2>&1)"
+	echo "$BUILD_OUTPUT"
+
+	if [ ! -f dist/index.html ]; then
+		echo "dist/index.html was not generated for Vite $version"
+		exit 1
+	fi
+
+	if find dist -mindepth 1 ! -name "index.html" | grep -q .; then
+		echo "Additional dist files were generated for Vite $version"
+		find dist -mindepth 1 ! -name "index.html"
+		exit 1
+	fi
+
+	if ! grep -q "<style" dist/index.html; then
+		echo "CSS was not inlined for Vite $version"
+		exit 1
+	fi
+
+	if grep -q '<script[^>]*src=' dist/index.html; then
+		echo "JavaScript was not inlined for Vite $version"
+		exit 1
+	fi
+
+	if ! grep -q "lazy-loaded" dist/index.html; then
+		echo "Dynamic imports were not bundled into the single file for Vite $version"
+		exit 1
+	fi
+
+	if [[ "$version" == 8.* ]] && grep -q "inlineDynamicImports option is deprecated" <<<"$BUILD_OUTPUT"; then
+		echo "Vite 8 deprecation warning is still present"
+		exit 1
+	fi
+
+	popd >/dev/null
 done
 
 echo ""


### PR DESCRIPTION
This PR adds proper Vite 8 support, with tests that cover the compatibility issue and the backward-compatibility path the current suite was missing.

## Fixed issues

There are two concrete Vite 8 problems behind this change:

1. `vite-plugin-singlefile` currently configures `build.rollupOptions.output.inlineDynamicImports = true`.
   On Vite 8, that goes through the deprecated Rollup alias and produces the warning reported in #118 :

   `inlineDynamicImports option is deprecated, please use codeSplitting: false instead.`

2. This repo itself does not build cleanly in a Vite 8 dependency tree unless `rollup` is available directly, because Vite 8 no longer brings it along in the same way older versions did.

The previous PR for Vite 8 was rejected because the existing tests still passed, which meant they were not exercising the part of the plugin that actually changed. That was correct: the old tests only covered the HTML/CSS replacement helpers, not the Vite config path.

## Changes

### Plugin config handling

For Vite 5/6/7, the plugin still uses the existing Rollup path:

- `build.rollupOptions.output.inlineDynamicImports = true`

For Vite 8, the plugin now detects the getter-backed deprecated `build.rollupOptions` alias and writes to the Rolldown path instead:

- `build.rolldownOptions.output.codeSplitting = false`

That removes the Vite 8 warning while preserving the old behavior for earlier supported Vite versions.

### Package metadata / local build compatibility

I also marked `rollup` as an optional peer and added it as a direct dev dependency so this repo can still build and type-check under Vite 8.

## Tests added

I added tests specifically around the Vite behavior the owner asked for.

1. Config-path tests
   - Verify the plugin sets `inlineDynamicImports` for the old Vite/Rollup config shape.
   - Verify the plugin sets `rolldownOptions.output.codeSplitting = false` for the Vite 8 config shape.
   - Verify output arrays are handled correctly on the Vite 8 path.

2. Real Vite build integration test
   - Builds a fixture app with the plugin.
   - Verifies the result is a single `dist/index.html`.
   - Verifies JS and CSS are inlined.
   - Verifies dynamic-imported code is still present in the single output.
   - On Vite 8, verifies the deprecation warning is not emitted.

3. Cross-version packaged-install matrix
   - Reworked `test-vite-versions.sh` so it tests the packed package in fresh throwaway apps instead of mutating this repo’s own dependency tree.
   - Verifies the plugin against:
     - Vite `5.4.11`
     - Vite `6.0.0`
     - Vite `7.0.0`
     - Vite `8.0.0`

## Verification

Ran locally:

- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:vite-versions`

I also manually checked the packed package against the latest published patch release in each supported major (`5.4.21`, `6.4.1`, `7.3.1`, `8.0.2`) to make sure this was not only true at the support floor.

- Closes #118
- Addresses #116